### PR TITLE
Add Helm chart for STAC Browser

### DIFF
--- a/helm-chart/browser/Chart.yaml
+++ b/helm-chart/browser/Chart.yaml
@@ -1,0 +1,24 @@
+apiVersion: v2
+name: browser
+description: STAC Browser for eoAPI
+# A chart can be either an 'application' or a 'library' chart.
+#
+# Application charts are a collection of templates that can be packaged into versioned archives
+# to be deployed.
+#
+# Library charts provide useful utilities or functions for the chart developer. They're included as
+# a dependency of application charts to inject those utilities and functions into the rendering
+# pipeline. Library charts do not define any templates and therefore cannot be deployed.
+type: application
+kubeVersion: ">=1.23.0-0"
+
+# This is the chart version. This version number should be incremented each time you make changes
+# to the chart and its templates, including the app version.
+# Versions are expected to follow Semantic Versioning (https://semver.org/)
+version: "0.1.0"
+
+# This is the version number of the application being deployed. This version number should be
+# incremented each time you make changes to the application. Versions are not expected to
+# follow Semantic Versioning. They should reflect the version the application is using.
+# It is recommended to use it with quotes.
+appVersion: "3.3.3"

--- a/helm-chart/browser/templates/configmap.yaml
+++ b/helm-chart/browser/templates/configmap.yaml
@@ -1,0 +1,10 @@
+{{- if (.Values.browser.enabled) }}
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: browser-envvar-configmap-{{ $.Release.Name }}
+data:
+  {{- range $envKey, $envValue := index .Values.browser.settings.envVars }}
+  {{ $envKey }}: {{ $envValue | quote }}
+  {{- end }}
+{{- end }}

--- a/helm-chart/browser/templates/deployment.yaml
+++ b/helm-chart/browser/templates/deployment.yaml
@@ -1,0 +1,27 @@
+{{- if (.Values.browser.enabled) }}
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: browser-{{ .Release.Name }}
+spec:
+  replicas: {{.Values.browser.replicaCount}}
+  selector:
+    matchLabels:
+      app: browser-{{ .Release.Name }}
+  template:
+    metadata:
+      labels:
+        app: browser-{{ .Release.Name }}
+    spec:
+      containers:
+        - name: browser
+          image: {{ .Values.browser.image.name }}:{{ .Values.browser.image.tag }}
+          ports:
+          - containerPort: 8080
+          envFrom:
+          # NOTE: there's no reason we need to use a `ConfigMap` or `Secret` here to get os env vars into the pod.
+          # we could just template them out here immediately with `value: $_` but this allows us
+          # to store them in k8s intermediately and change them and then bounce deploys if needed
+          - configMapRef:
+              name: browser-envvar-configmap-{{ $.Release.Name }}
+{{- end }}

--- a/helm-chart/browser/templates/ingress-nginx.yaml
+++ b/helm-chart/browser/templates/ingress-nginx.yaml
@@ -1,0 +1,33 @@
+{{- if (and (.Values.ingress.enabled) (eq .Values.ingress.className "nginx")) }}
+{{- if (.Values.browser.enabled) }}
+# We need a separate ingress because browser does not play well with nginx rewrite_path directive
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: nginx-browser-ingress-shared-{{ $.Release.Name }}
+  labels:
+    app: nginxsharedingress
+  annotations:
+    nginx.ingress.kubernetes.io/use-regex: "true"
+    nginx.ingress.kubernetes.io/enable-cors: "true"
+    # enable-access-log is required for nginx to dump metrics about path rewrites for prometheus to scrape
+    nginx.ingress.kubernetes.io/enable-access-log: "true"
+    {{- if (and (.Values.ingress.tls.enabled) (.Values.ingress.tls.certManager)) }}
+    cert-manager.io/issuer: {{ .Values.ingress.tls.certManagerIssuer }}
+    {{- end }}  
+spec:
+  ingressClassName: {{ .Values.ingress.className }}
+  rules:
+    - http:
+        paths:
+        - pathType: Prefix
+          path: /
+          backend:
+            service:
+              name: browser
+              port:
+                number: {{ $.Values.service.port }}
+{{/* END: if (.Values.browser.enabled) */}}
+{{- end }}
+{{/* END: if (and (.Values.ingress.enabled) (eq .Values.ingress.className "nginx")) */}}
+{{- end }}

--- a/helm-chart/browser/templates/service.yaml
+++ b/helm-chart/browser/templates/service.yaml
@@ -1,0 +1,20 @@
+{{- if (.Values.browser.enabled) }}
+apiVersion: v1
+kind: Service
+metadata:
+  labels:
+    app: browser
+  name: browser
+spec:
+  {{- if (and ($.Values.ingress.className) (eq $.Values.ingress.className "nginx")) }}
+  type: "ClusterIP"
+  {{- else }}
+  type: "NodePort"
+  {{- end }}
+  ports:
+  - name: '{{ $.Values.service.port }}'
+    port: {{ $.Values.service.port }}
+    targetPort: {{ $.Values.service.port }}
+  selector:
+    app: browser-{{ .Release.Name }}
+{{- end }}

--- a/helm-chart/browser/values.yaml
+++ b/helm-chart/browser/values.yaml
@@ -1,0 +1,22 @@
+
+ingress:
+  enabled: true
+  className: "nginx"
+  host: ""
+  tls:
+    enabled: false
+    secretName: eoapi-tls
+    certManager: false
+    certManagerIssuer: letsencrypt-prod
+    certManagerEmail: ""
+
+browser:
+  enabled: true
+  image:
+    name: ghcr.io/radiantearth/stac-browser
+    tag: 3.3.3
+  replicaCount: 1
+  settings:
+    envVars:
+      SB_catalogUrl: "/stac"
+      SB_detectLocaleFromBrowser: "false"


### PR DESCRIPTION
This PR adds a Helm chart for the STAC Browser. No `pathPrefix` is used.